### PR TITLE
fix(observe): new telemetry scope

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     profiles:
       - all
       - observe
-    image: icr.io/i-am-bee/bee-observe:0.0.5
+    image: icr.io/i-am-bee/bee-observe:0.0.6
     ports:
       - "4002:3000"
     command: >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bee-agent-framework-starter",
+  "name": "beeai-framework-starter",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bee-agent-framework-starter",
+      "name": "beeai-framework-starter",
       "version": "0.0.1",
       "dependencies": {
         "@opentelemetry/sdk-node": "^0.57.0",


### PR DESCRIPTION
I updated the bee-observe service to a new version `0.0.6` that correctly filters the new open telemetry scope defined in the framework monorepo. 